### PR TITLE
Fix type name inside mapper dict to avoid collision

### DIFF
--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -2,8 +2,7 @@
 """
 Copyright (C) 2015, marazt. All rights reserved.
 """
-from enum import Enum
-from inspect import getmembers, isroutine, isclass
+from inspect import getmembers, isroutine
 
 from mapper.casedict import CaseDict
 from mapper.object_mapper_exception import ObjectMapperException
@@ -179,8 +178,8 @@ class ObjectMapper(object):
                     #         not __builtins__.get(type(from_props[prop]).__name__):
                     #     self.map(from_props[prop], key_to, allow_none=allow_none)
                     # else:
-                        setattr(inst, prop, from_props[prop])
-                        # case when target attribute is not mapped (can be extended)
+                    setattr(inst, prop, from_props[prop])
+                    # case when target attribute is not mapped (can be extended)
             else:
                 raise ObjectMapperException("No mapping defined for {0} -> {1}".format(key_from, key_to))
 

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -171,14 +171,14 @@ class ObjectMapper(object):
                     if prop not in from_props:
                         continue
 
-                    prop_to_type = type(from_props[prop])
+                    # prop_to_type = type(from_props[prop])
 
-                    if isclass(prop_to_type) and \
-                            not issubclass(prop_to_type, Enum) and \
-                            prop_to_type is not type(None) and \
-                            not __builtins__.get(type(from_props[prop]).__name__):
-                        self.map(from_props[prop], key_to, allow_none=allow_none)
-                    else:
+                    # if isclass(prop_to_type) and \
+                    #         not issubclass(prop_to_type, Enum) and \
+                    #         prop_to_type is not type(None) and \
+                    #         not __builtins__.get(type(from_props[prop]).__name__):
+                    #     self.map(from_props[prop], key_to, allow_none=allow_none)
+                    # else:
                         setattr(inst, prop, from_props[prop])
                         # case when target attribute is not mapped (can be extended)
             else:

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -167,19 +167,9 @@ class ObjectMapper(object):
 
                 else:
                     # try find property with the same name in the source
-                    if prop not in from_props:
-                        continue
-
-                    # prop_to_type = type(from_props[prop])
-
-                    # if isclass(prop_to_type) and \
-                    #         not issubclass(prop_to_type, Enum) and \
-                    #         prop_to_type is not type(None) and \
-                    #         not __builtins__.get(type(from_props[prop]).__name__):
-                    #     self.map(from_props[prop], key_to, allow_none=allow_none)
-                    # else:
-                    setattr(inst, prop, from_props[prop])
-                    # case when target attribute is not mapped (can be extended)
+                    if prop in from_props:
+                        setattr(inst, prop, from_props[prop])
+                        # case when target attribute is not mapped (can be extended)
             else:
                 raise ObjectMapperException("No mapping defined for {0} -> {1}".format(key_from, key_to))
 

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -102,7 +102,9 @@ class ObjectMapper(object):
         if key_from in self.mappings:
             inner_map = self.mappings[key_from]
             if key_to in inner_map:
-                raise ObjectMapperException("Mapping for {0} -> {1} already exists".format(key_from, key_to))
+                raise ObjectMapperException(
+                    "Mapping for {0}.{1} -> {2}.{3} already exists".format(key_from.__module__, key_from.__name__,
+                                                                   key_to.__module__, key_to.__name__))
             else:
                 inner_map[key_to] = mapping
         else:
@@ -171,6 +173,8 @@ class ObjectMapper(object):
                         setattr(inst, prop, from_props[prop])
                         # case when target attribute is not mapped (can be extended)
             else:
-                raise ObjectMapperException("No mapping defined for {0} -> {1}".format(key_from, key_to))
+                raise ObjectMapperException(
+                    "No mapping defined for {0}.{1} -> {2}.{3}".format(key_from.__module__, key_from.__name__,
+                                                                       key_to.__module__, key_to.__name__))
 
         return inst

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -128,8 +128,8 @@ class ObjectMapper(object):
             from_obj.__dict__
 
         inst = to_type()
-        key_from = from_obj.__class__.__name__
-        key_to = to_type.__name__
+        key_from = from_obj.__class__
+        key_to = to_type
 
         def not_private(s):
             return not s.startswith('_')

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -2,9 +2,12 @@
 """
 Copyright (C) 2015, marazt. All rights reserved.
 """
-from mapper.object_mapper_exception import ObjectMapperException
+from enum import Enum
+from inspect import getmembers, isroutine, isclass
+
 from mapper.casedict import CaseDict
-from inspect import getmembers, isroutine
+from mapper.object_mapper_exception import ObjectMapperException
+
 
 class ObjectMapper(object):
     """
@@ -91,8 +94,8 @@ class ObjectMapper(object):
 
         :return: None
         """
-        key_from = type_from.__name__
-        key_to = type_to.__name__
+        key_from = type_from
+        key_to = type_to
 
         if mapping is None:
             mapping = {}
@@ -165,7 +168,17 @@ class ObjectMapper(object):
 
                 else:
                     # try find property with the same name in the source
-                    if prop in from_props:
+                    if prop not in from_props:
+                        continue
+
+                    prop_to_type = type(from_props[prop])
+
+                    if isclass(prop_to_type) and \
+                            not issubclass(prop_to_type, Enum) and \
+                            prop_to_type is not type(None) and \
+                            not __builtins__.get(type(from_props[prop]).__name__):
+                        self.map(from_props[prop], key_to, allow_none=allow_none)
+                    else:
                         setattr(inst, prop, from_props[prop])
                         # case when target attribute is not mapped (can be extended)
             else:

--- a/tests/object_mapper_test.py
+++ b/tests/object_mapper_test.py
@@ -3,14 +3,18 @@
 Copyright (C) 2015, marazt. All rights reserved.
 """
 import unittest
-
 from datetime import datetime
+
 from mapper.object_mapper import ObjectMapper
 from mapper.object_mapper_exception import ObjectMapperException
+
+NO_MAPPING_FOUND_EXCEPTION_MESSAGE = "No mapping defined for {0}.{1} -> {2}.{3}"
+MAPPING_ALREADY_EXISTS_EXCEPTION_MESSAGE = "Mapping for {0}.{1} -> {2}.{3} already exists"
 
 
 class ToTestClass(object):
     """ To Test Class """
+
     def __init__(self):
         self.name = ""
         self.date = ""
@@ -19,6 +23,7 @@ class ToTestClass(object):
 
 class ToTestClassTwo(object):
     """ To Test Class Two """
+
     def __init__(self):
         self.all = ""
         pass
@@ -26,12 +31,14 @@ class ToTestClassTwo(object):
 
 class ToTestClassEmpty(object):
     """ To Test Class Empty """
+
     def __init__(self):
         pass
 
 
 class FromTestClass(object):
     """ From Test Class """
+
     def __init__(self):
         self.name = "Igor"
         self.surname = "Hnizdo"
@@ -102,7 +109,8 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Arrange
         exc = False
-        msg = "Mapping for FromTestClass -> ToTestClass already exists"
+        msg = MAPPING_ALREADY_EXISTS_EXCEPTION_MESSAGE.format(FromTestClass.__module__, FromTestClass.__name__,
+                                                              ToTestClass.__module__, ToTestClass.__name__)
         mapper = ObjectMapper()
 
         mapper.create_map(FromTestClass, ToTestClass)
@@ -186,9 +194,9 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Arrange
         exc = False
-        msg = "No mapping defined for FromTestClass -> ToTestClass"
         from_class = FromTestClass()
-
+        msg = NO_MAPPING_FOUND_EXCEPTION_MESSAGE.format(from_class.__module__, from_class.__class__.__name__,
+                                                        ToTestClass.__module__, ToTestClass.__name__)
         mapper = ObjectMapper()
 
         # Act
@@ -225,11 +233,13 @@ class ObjectMapperTest(unittest.TestCase):
         # Arrange
         class ToTestClass2(object):
             """ To Test Class 2 """
+
             def __init__(self):
                 self.name = ""
 
         class FromTestClass2(object):
             """ From Test Class 2 """
+
             def __init__(self):
                 self.Name = "Name"
 
@@ -267,6 +277,7 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Arrange
         _propNames = ['name', 'date']
+
         class ToCustomDirClass(object):
             def __dir__(self):
                 props = list(self.__dict__.keys())
@@ -304,16 +315,16 @@ class ObjectMapperTest(unittest.TestCase):
 
     def test_mapping_excluded_field(self):
         """Test mapping with excluded fields"""
-        #Arrange
+        # Arrange
         from_class = FromTestClass()
         mapper = ObjectMapper()
         mapper.create_map(FromTestClass, ToTestClass)
 
-        #Act
+        # Act
         result = mapper.map(FromTestClass(), ToTestClass, excluded=['date'])
 
-        #Assert
-        print(result)      
+        # Assert
+        print(result)
         self.assertTrue(isinstance(result, ToTestClass), "Type must be ToTestClass")
         self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
         self.assertEqual(result.date, '', "Date mapping must be equal")


### PR DESCRIPTION
This PR addresses issue #16, allowing mapping between classes with the same name but in different namespaces.

Changes in  exception messages:
*  From `No mapping defined for FromTestClass -> ToTestClass` to `No mapping defined for object_mapper_test.FromTestClass -> object_mapper_test.ToTestClass`.
* From `Mapping for FromTestClass -> ToTestClass already exists` to `Mapping for object_mapper_test.FromTestClass -> object_mapper_test.ToTestClass already exists`