### PR TITLE
support for mapping nested objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 # Idea
 .idea
 .python-version
+
+# VSCode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python3
+        - choco install python3 --version 3.7.3
         - pip install virtualenv
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "python.formatting.provider": "autopep8",
+  "python.pythonPath": "F:\\Anaconda3\\envs\\mlexp\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.formatting.provider": "autopep8",
-  "python.pythonPath": "F:\\Anaconda3\\envs\\mlexp\\python.exe"
-}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Object Mapper
 
 **Version**
-1.0.6
+1.1.0
 
 **Author**
 marazt
@@ -15,45 +15,46 @@ marazt
 The MIT License (MIT)
 
 **Last updated**
-28 October 2018
+10 June 2019
 
 **Package Download**
 https://pypi.python.org/pypi/object-mapper
+
 ---
 
 ## Versions
 
+**1.1.0 - 2019/06/10**
+
+- Add basic support for nested object, thanks [@direbearform](https://github.com/direbearform)
+
 **1.0.6 - 2018/10/28**
 
-* Added ability to specify excluded fields, thanks [@uralov](https://github.com/uralov)
+- Added ability to specify excluded fields, thanks [@uralov](https://github.com/uralov)
 
 **1.0.5 - 2018/02/21**
 
-* Support for dynamic properties [@nijm](https://github.com/nijm)
+- Support for dynamic properties [@nijm](https://github.com/nijm)
 
 **1.0.4 - 2017/11/03**
 
-* Migration to new Pypi.org deployment
+- Migration to new Pypi.org deployment
 
 **1.0.3 - 2015/05/15**
 
-* Added support for None mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
-
+- Added support for None mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
 
 **1.0.2 - 2015/05/06**
 
-* Added support for case insensitivity mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
-
+- Added support for case insensitivity mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
 
 **1.0.1 - 2015/02/19**
 
-* Fix of the package information
-
+- Fix of the package information
 
 **1.0.0 - 2015/02/19**
 
-* Initial version
-
+- Initial version
 
 ## About
 
@@ -64,80 +65,80 @@ It helps you to create objects between project layers (data layer, service layer
 
 1. **Mapping of the properties without mapping definition**
 
-  In this case are mapped only these properties of the target class which
-  are in target and source classes. Other properties are not mapped.
-  Suppose we have class `A` with attributes `name` and `last_name`
-  and class `B` with attribute `name`.
-  Initialization of the ObjectMapper will be:
+In this case are mapped only these properties of the target class which
+are in target and source classes. Other properties are not mapped.
+Suppose we have class `A` with attributes `name` and `last_name`
+and class `B` with attribute `name`.
+Initialization of the ObjectMapper will be:
 
-  ```python
-  mapper = ObjectMapper()
-  mapper.create_map(A, B)
-  instance_b = mapper.map(A(), B)
-  ```
+```python
+mapper = ObjectMapper()
+mapper.create_map(A, B)
+instance_b = mapper.map(A(), B)
+```
 
-  In this case, value of A.name will be copied into B.name.
+In this case, value of A.name will be copied into B.name.
 
 2. **Mapping with defined mapping functions**
 
-  Suppose we have class `A` with attributes `first_name` and `last_name`
-  , class `B` with attribute `full_name` and class `C` with attribute reverse_name.
-  And want to map it in a way `B.full_name = A.first_name + A.last_name` and
-  `C.reverse_name = A.last_name + A.first_name`
-  Initialization of the ObjectMapper will be:
+Suppose we have class `A` with attributes `first_name` and `last_name`
+, class `B` with attribute `full_name` and class `C` with attribute reverse_name.
+And want to map it in a way `B.full_name = A.first_name + A.last_name` and
+`C.reverse_name = A.last_name + A.first_name`
+Initialization of the ObjectMapper will be:
 
-  ```python
-  mapper = ObjectMapper()
-  mapper.create_map(A, B, {'name': lambda a : a.first_name + " " + a.last_name})
-  mapper.create_map(A, C, {'name': lambda a : a.last_name + " " + a.first_name})
+```python
+mapper = ObjectMapper()
+mapper.create_map(A, B, {'name': lambda a : a.first_name + " " + a.last_name})
+mapper.create_map(A, C, {'name': lambda a : a.last_name + " " + a.first_name})
 
-  instance_b = mapper.map(A(), B)
-  instance_c = mapper.map(A(), C)
-  ```
+instance_b = mapper.map(A(), B)
+instance_c = mapper.map(A(), C)
+```
 
-  In this case, to the `B.name` will be mapped `A.first_name + " " + A.last_name`
-  In this case, to the `C.name` will be mapped `A.last_name + " " + A.first_name`
+In this case, to the `B.name` will be mapped `A.first_name + " " + A.last_name`
+In this case, to the `C.name` will be mapped `A.last_name + " " + A.first_name`
 
 3. **Mapping suppression**
 
-  For some purposes, it can be needed to suppress some mapping.
-  Suppose we have class `A` with attributes `name` and `last_name`
-  and class `B` with attributes `name` and `last_name`.
-  And we want to map only the `A.name` into `B.name`, but not `A.last_name` to
-  `B.last_name`
-  Initialization of the ObjectMapper will be:
+For some purposes, it can be needed to suppress some mapping.
+Suppose we have class `A` with attributes `name` and `last_name`
+and class `B` with attributes `name` and `last_name`.
+And we want to map only the `A.name` into `B.name`, but not `A.last_name` to
+`B.last_name`
+Initialization of the ObjectMapper will be:
 
-  ```python
-  mapper = ObjectMapper()
-  mapper.create_map(A, B, {'last_name': None})
+```python
+mapper = ObjectMapper()
+mapper.create_map(A, B, {'last_name': None})
 
-  instance_b = mapper.map(A(), B)
-  ```
+instance_b = mapper.map(A(), B)
+```
 
-  In this case, value of A.name will be copied into `B.name` automatically by the attribute name `name`.
-  Attribute `A.last_name` will be not mapped thanks the suppression (lambda function is None).
+In this case, value of A.name will be copied into `B.name` automatically by the attribute name `name`.
+Attribute `A.last_name` will be not mapped thanks the suppression (lambda function is None).
 
 4. **Case insensitive mapping**
 
-  Suppose we have class `A` with attributes `Name` and `Age` and
-  class `B` with attributes `name` and `age` and we want to map `A` to `B` in a way
-  `B.name` = `A.Name` and `B.age` = `A.Age`
-  Initialization of the ObjectMapper will be:
+Suppose we have class `A` with attributes `Name` and `Age` and
+class `B` with attributes `name` and `age` and we want to map `A` to `B` in a way
+`B.name` = `A.Name` and `B.age` = `A.Age`
+Initialization of the ObjectMapper will be:
 
-  ```python
-  mapper = ObjectMapper()
-  mapper.create_map(A, B)
-  instance_b = mapper.map(A(), B, ignore_case=True)
-  ```
+```python
+mapper = ObjectMapper()
+mapper.create_map(A, B)
+instance_b = mapper.map(A(), B, ignore_case=True)
+```
 
-  In this case, the value of A.Name will be copied into B.name and
-  the value of A.Age will be copied into B.age.
+In this case, the value of A.Name will be copied into B.name and
+the value of A.Age will be copied into B.age.
 
-  **Note:** You can find more examples in tests package
+**Note:** You can find more examples in tests package
 
 ## Installation
 
-* Download this project
-* Download from Pypi: https://pypi.python.org/pypi/object-mapper
+- Download this project
+- Download from Pypi: https://pypi.python.org/pypi/object-mapper
 
 ### ENJOY IT!

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://pypi.python.org/pypi/object-mapper
 
 **1.1.0 - 2019/07/13**
 
-- Add basic support for nested object, thanks [@direbearform](https://github.com/direbearform)
+* Add basic support for nested object, thanks [@direbearform](https://github.com/direbearform)
 
 **1.0.7 - 2019/06/19**
 
@@ -35,31 +35,35 @@ https://pypi.python.org/pypi/object-mapper
 
 **1.0.6 - 2018/10/28**
 
-- Added ability to specify excluded fields, thanks [@uralov](https://github.com/uralov)
+* Added ability to specify excluded fields, thanks [@uralov](https://github.com/uralov)
 
 **1.0.5 - 2018/02/21**
 
-- Support for dynamic properties [@nijm](https://github.com/nijm)
+* Support for dynamic properties [@nijm](https://github.com/nijm)
 
 **1.0.4 - 2017/11/03**
 
-- Migration to new Pypi.org deployment
+* Migration to new Pypi.org deployment
 
 **1.0.3 - 2015/05/15**
 
-- Added support for None mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
+* Added support for None mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
+
 
 **1.0.2 - 2015/05/06**
 
-- Added support for case insensitivity mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
+* Added support for case insensitivity mapping [@ramiabughazaleh](https://github.com/ramiabughazaleh)
+
 
 **1.0.1 - 2015/02/19**
 
-- Fix of the package information
+* Fix of the package information
+
 
 **1.0.0 - 2015/02/19**
 
-- Initial version
+* Initial version
+
 
 ## About
 
@@ -70,80 +74,80 @@ It helps you to create objects between project layers (data layer, service layer
 
 1. **Mapping of the properties without mapping definition**
 
-In this case are mapped only these properties of the target class which
-are in target and source classes. Other properties are not mapped.
-Suppose we have class `A` with attributes `name` and `last_name`
-and class `B` with attribute `name`.
-Initialization of the ObjectMapper will be:
+  In this case are mapped only these properties of the target class which
+  are in target and source classes. Other properties are not mapped.
+  Suppose we have class `A` with attributes `name` and `last_name`
+  and class `B` with attribute `name`.
+  Initialization of the ObjectMapper will be:
 
-```python
-mapper = ObjectMapper()
-mapper.create_map(A, B)
-instance_b = mapper.map(A(), B)
-```
+  ```python
+  mapper = ObjectMapper()
+  mapper.create_map(A, B)
+  instance_b = mapper.map(A(), B)
+  ```
 
-In this case, value of A.name will be copied into B.name.
+  In this case, value of A.name will be copied into B.name.
 
 2. **Mapping with defined mapping functions**
 
-Suppose we have class `A` with attributes `first_name` and `last_name`
-, class `B` with attribute `full_name` and class `C` with attribute reverse_name.
-And want to map it in a way `B.full_name = A.first_name + A.last_name` and
-`C.reverse_name = A.last_name + A.first_name`
-Initialization of the ObjectMapper will be:
+  Suppose we have class `A` with attributes `first_name` and `last_name`
+  , class `B` with attribute `full_name` and class `C` with attribute reverse_name.
+  And want to map it in a way `B.full_name = A.first_name + A.last_name` and
+  `C.reverse_name = A.last_name + A.first_name`
+  Initialization of the ObjectMapper will be:
 
-```python
-mapper = ObjectMapper()
-mapper.create_map(A, B, {'name': lambda a : a.first_name + " " + a.last_name})
-mapper.create_map(A, C, {'name': lambda a : a.last_name + " " + a.first_name})
+  ```python
+  mapper = ObjectMapper()
+  mapper.create_map(A, B, {'name': lambda a : a.first_name + " " + a.last_name})
+  mapper.create_map(A, C, {'name': lambda a : a.last_name + " " + a.first_name})
 
-instance_b = mapper.map(A(), B)
-instance_c = mapper.map(A(), C)
-```
+  instance_b = mapper.map(A(), B)
+  instance_c = mapper.map(A(), C)
+  ```
 
-In this case, to the `B.name` will be mapped `A.first_name + " " + A.last_name`
-In this case, to the `C.name` will be mapped `A.last_name + " " + A.first_name`
+  In this case, to the `B.name` will be mapped `A.first_name + " " + A.last_name`
+  In this case, to the `C.name` will be mapped `A.last_name + " " + A.first_name`
 
 3. **Mapping suppression**
 
-For some purposes, it can be needed to suppress some mapping.
-Suppose we have class `A` with attributes `name` and `last_name`
-and class `B` with attributes `name` and `last_name`.
-And we want to map only the `A.name` into `B.name`, but not `A.last_name` to
-`B.last_name`
-Initialization of the ObjectMapper will be:
+  For some purposes, it can be needed to suppress some mapping.
+  Suppose we have class `A` with attributes `name` and `last_name`
+  and class `B` with attributes `name` and `last_name`.
+  And we want to map only the `A.name` into `B.name`, but not `A.last_name` to
+  `B.last_name`
+  Initialization of the ObjectMapper will be:
 
-```python
-mapper = ObjectMapper()
-mapper.create_map(A, B, {'last_name': None})
+  ```python
+  mapper = ObjectMapper()
+  mapper.create_map(A, B, {'last_name': None})
 
-instance_b = mapper.map(A(), B)
-```
+  instance_b = mapper.map(A(), B)
+  ```
 
-In this case, value of A.name will be copied into `B.name` automatically by the attribute name `name`.
-Attribute `A.last_name` will be not mapped thanks the suppression (lambda function is None).
+  In this case, value of A.name will be copied into `B.name` automatically by the attribute name `name`.
+  Attribute `A.last_name` will be not mapped thanks the suppression (lambda function is None).
 
 4. **Case insensitive mapping**
 
-Suppose we have class `A` with attributes `Name` and `Age` and
-class `B` with attributes `name` and `age` and we want to map `A` to `B` in a way
-`B.name` = `A.Name` and `B.age` = `A.Age`
-Initialization of the ObjectMapper will be:
+  Suppose we have class `A` with attributes `Name` and `Age` and
+  class `B` with attributes `name` and `age` and we want to map `A` to `B` in a way
+  `B.name` = `A.Name` and `B.age` = `A.Age`
+  Initialization of the ObjectMapper will be:
 
-```python
-mapper = ObjectMapper()
-mapper.create_map(A, B)
-instance_b = mapper.map(A(), B, ignore_case=True)
-```
+  ```python
+  mapper = ObjectMapper()
+  mapper.create_map(A, B)
+  instance_b = mapper.map(A(), B, ignore_case=True)
+  ```
 
-In this case, the value of A.Name will be copied into B.name and
-the value of A.Age will be copied into B.age.
+  In this case, the value of A.Name will be copied into B.name and
+  the value of A.Age will be copied into B.age.
 
-**Note:** You can find more examples in tests package
+  **Note:** You can find more examples in tests package
 
 ## Installation
 
-- Download this project
-- Download from Pypi: https://pypi.python.org/pypi/object-mapper
+* Download this project
+* Download from Pypi: https://pypi.python.org/pypi/object-mapper
 
 ### ENJOY IT!

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ https://pypi.python.org/pypi/object-mapper
 **Build Status**
 [![Build Status](https://travis-ci.com/marazt/object-mapper.svg?branch=master)](https://travis-ci.com/marazt/object-mapper)
 
+---
+
 ## Versions
 
 **1.1.0 - 2019/07/13**

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,6 @@ Object Mapper
 
 **Package Download** https://pypi.python.org/pypi/object-mapper ---
 
----
-
 Versions
 --------
 

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -101,8 +101,10 @@ class ObjectMapper(object):
 
         if (type(type_from) is not type):
             raise ObjectMapperException(f"type_from must be a type")
+
         if (type(type_to) is not type):
             raise ObjectMapperException(f"type_to must be a type")
+
         if (mapping is not None and not isinstance(mapping, Dict)):
             raise ObjectMapperException(f"mapping, if provided, must be a Dict type")
 
@@ -162,7 +164,7 @@ class ObjectMapper(object):
                 raise ObjectMapperException(f"No mapping defined for {key_from} to {key_to}")
             key_to_cls = self.mappings[key_from][key_to][0]
             custom_mappings = self.mappings[key_from][key_to][1]
-
+        
         # Currently, all target class data members need to have default value
         # Object with __init__ that carries required non-default arguments are not supported
         inst = key_to_cls()
@@ -173,14 +175,14 @@ class ObjectMapper(object):
         def not_excluded(s):
             return not (excluded and s in excluded)
 
-        def is_included(s):
-            return included and s in included
+        def is_included(s, mapping):
+            return (included and s in included) or (mapping and s in mapping)
 
         from_obj_attributes = getmembers(from_obj, lambda a: not isroutine(a))
         from_obj_dict = {k: v for k, v in from_obj_attributes}
 
         to_obj_attributes = getmembers(inst, lambda a: not isroutine(a))
-        to_obj_dict = {k: v for k, v in to_obj_attributes if not_excluded(k) and (not_private(k) or is_included(k))}
+        to_obj_dict = {k: v for k, v in to_obj_attributes if not_excluded(k) and (not_private(k) or is_included(k, custom_mappings))}
 
         if ignore_case:
             from_props = CaseDict(from_obj_dict)

--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -2,15 +2,19 @@
 """
 Copyright (C) 2015, marazt. All rights reserved.
 """
+from typing import List, Dict
 from mapper.object_mapper_exception import ObjectMapperException
 from mapper.casedict import CaseDict
 from inspect import getmembers, isroutine
+from datetime import date, datetime
 
 class ObjectMapper(object):
     """
     Base class for mapping class attributes from one class to another one
     Supports mapping conversions too
     """
+
+    primitive_types = { int, str, bool, date, datetime }
 
     def __init__(self):
         """Constructor
@@ -58,7 +62,7 @@ class ObjectMapper(object):
             mapper = ObjectMapper()
             mapper.create_map(A, B, {'last_name': None})
 
-            instance_b = mapper.map(A(), B)
+            instance_b = mapper.map(A())
 
             In this case, value of A.name will be copied into B.name automatically by the attribute name 'name'.
             Attribute A.last_name will be not mapped thanks the suppression (lambda function is None).
@@ -70,18 +74,21 @@ class ObjectMapper(object):
             Initialization of the ObjectMapper will be:
             mapper = ObjectMapper()
             mapper.create_map(A, B)
-            instance_b = mapper.map(A(), B, ignore_case=True)
+            instance_b = mapper.map(A(), ignore_case=True)
 
             In this case, the value of A.Name will be copied into B.name and
             the value of A.Age will be copied into B.age.
 
         :return: Instance of the ObjectMapper
         """
-        # self.to_type = to_type
+
+        # mapping is a 2-layer dict keyed by source type then by dest type, and stores two things in a tuple:
+        #  - the destination type class
+        #  - custom mapping functions, if any
         self.mappings = {}
         pass
 
-    def create_map(self, type_from, type_to, mapping=None):
+    def create_map(self, type_from: type, type_to: type, mapping: Dict =None):
         """Method for adding mapping definitions
 
         :param type_from: source type
@@ -91,23 +98,29 @@ class ObjectMapper(object):
 
         :return: None
         """
-        key_from = type_from.__name__
-        key_to = type_to.__name__
 
-        if mapping is None:
-            mapping = {}
+        if (type(type_from) is not type):
+            raise ObjectMapperException(f"type_from must be a type")
+        if (type(type_to) is not type):
+            raise ObjectMapperException(f"type_to must be a type")
+        if (mapping is not None and not isinstance(mapping, Dict)):
+            raise ObjectMapperException(f"mapping, if provided, must be a Dict type")
+
+        key_from = f"{type_from.__module__}.{type_from.__name__}"
+        key_to = f"{type_to.__module__}.{type_to.__name__}"
 
         if key_from in self.mappings:
             inner_map = self.mappings[key_from]
             if key_to in inner_map:
                 raise ObjectMapperException("Mapping for {0} -> {1} already exists".format(key_from, key_to))
             else:
-                inner_map[key_to] = mapping
+                inner_map[key_to] = (type_to, mapping)
         else:
             self.mappings[key_from] = {}
-            self.mappings[key_from][key_to] = mapping
+            self.mappings[key_from][key_to] = (type_to, mapping)
 
-    def map(self, from_obj, to_type, ignore_case=False, allow_none=False, excluded=None):
+
+    def map(self, from_obj, to_type: type=type(None), ignore_case=False, allow_none=False, excluded=None, allow_unmapped=False):
         """Method for creating target object instance
 
         :param from_obj: source object to be mapped from
@@ -115,6 +128,7 @@ class ObjectMapper(object):
         :param ignore_case: if set to true, ignores attribute case when performing the mapping
         :param allow_none: if set to true, returns None if the source object is None; otherwise throws an exception
         :param excluded: A list of fields to exclude when performing the mapping
+        :param allow_unmapped: if set to true, copy over the non-primitive object that didn't have a mapping defined; otherwise exception
 
         :return: Instance of the target class with mapped attributes
         """
@@ -124,9 +138,33 @@ class ObjectMapper(object):
             # one of the tests is explicitly checking for an attribute error on __dict__ if it's not set
             from_obj.__dict__
 
-        inst = to_type()
-        key_from = from_obj.__class__.__name__
-        key_to = to_type.__name__
+        key_from = f"{from_obj.__class__.__module__}.{from_obj.__class__.__name__}"
+
+        if key_from not in self.mappings:
+            raise ObjectMapperException(f"No mapping defined for {key_from}")
+
+        custom_mappings = None
+        key_to_cls = type(None)
+        
+        if to_type is None or to_type is type(None):
+            # automatically infer to to_type
+            # if this is a nested call and we do not currently support more than one to_types
+            assert(len(self.mappings[key_from]) > 0)
+            if len(self.mappings[key_from]) > 1:
+                raise ObjectMapperException(f"Ambiguous type mapping exists for {key_from}, must specifiy to_type explicitly")
+            the_only_key_to = next(iter(self.mappings[key_from]))
+            key_to_cls = self.mappings[key_from][the_only_key_to][0]
+            custom_mappings = self.mappings[key_from][the_only_key_to][1]
+        else:
+            key_to = f"{to_type.__module__}.{to_type.__name__}"
+            if key_to not in self.mappings[key_from]:
+                raise ObjectMapperException(f"No mapping defined for {key_from} to {key_to}")
+            key_to_cls = self.mappings[key_from][key_to][0]
+            custom_mappings = self.mappings[key_from][key_to][1]
+
+        # Currently, all target class data members need to have default value
+        # Object with __init__ that carries required non-default arguments are not supported
+        inst = key_to_cls()
 
         def not_private(s):
             return not s.startswith('_')
@@ -148,27 +186,54 @@ class ObjectMapper(object):
             from_props = from_obj_dict
             to_props = to_obj_dict
 
-        for prop in to_props:
-            if self.mappings is not None \
-                    and key_from in self.mappings \
-                    and key_to in self.mappings[key_from]:
-                if prop in self.mappings[key_from][key_to]:
-                    # take mapping function
-                    try:
-                        fnc = self.mappings[key_from][key_to][prop]
-                        if fnc is not None:
-                            setattr(inst, prop, fnc(from_obj))
-                            # none suppress mapping
-                    except Exception:
-                        raise ObjectMapperException("Invalid mapping function while setting property {0}.{1}".
-                                                    format(inst.__class__.__name__, prop))
-
+        def map_obj(o, allow_unmapped):
+            if o is not None:
+                key_from_child_cls = o.__class__
+                key_from_child = f"{key_from_child_cls.__module__}.{key_from_child_cls.__name__}"
+                if (key_from_child in self.mappings):
+                    # if key_to has a mapping defined, nests the map() call
+                    return self.map(o, type(None), ignore_case, allow_none, excluded, allow_unmapped)
+                elif (key_from_child_cls in ObjectMapper.primitive_types):
+                    # allow primitive types without mapping
+                    return o
                 else:
-                    # try find property with the same name in the source
-                    if prop in from_props:
-                        setattr(inst, prop, from_props[prop])
-                        # case when target attribute is not mapped (can be extended)
+                    # fail complex type conversion if mapping was not defined, unless explicitly allowed
+                    if allow_unmapped:
+                        return o
+                    else:
+                        raise ObjectMapperException(f"No mapping defined for {key_from_child}")
             else:
-                raise ObjectMapperException("No mapping defined for {0} -> {1}".format(key_from, key_to))
+                return None
+
+        for prop in to_props:
+            
+            val = None
+            suppress_mapping = False
+            
+            # mapping function take precedence over complex type mapping
+            if custom_mappings is not None and prop in custom_mappings:
+                try:
+                    fnc = custom_mappings[prop]
+                    if fnc is not None:
+                        val = fnc(from_obj)
+                    else:
+                        suppress_mapping = True
+                except Exception:
+                    raise ObjectMapperException("Invalid mapping function while setting property {0}.{1}".
+                                                format(inst.__class__.__name__, prop))
+
+            elif prop in from_props:
+                # try find property with the same name in the source
+                from_obj_child = from_props[prop]
+                if isinstance(from_obj_child, List):
+                    val = [map_obj(from_obj_child_i, allow_unmapped) for from_obj_child_i in from_obj_child]
+                else:
+                    val = map_obj(from_obj_child, allow_unmapped)
+            
+            else:
+                suppress_mapping = True
+
+            if not suppress_mapping:
+                setattr(inst, prop, val)
 
         return inst

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.6',
+    version='1.1.0',
 
     description="ObjectMapper is a class for automatic object mapping. It helps you to create objects between\
                 project layers (data layer, service layer, view) in a simple, transparent way.",

--- a/tests/object_mapper_test.py
+++ b/tests/object_mapper_test.py
@@ -382,6 +382,24 @@ class ObjectMapperTest(unittest.TestCase):
         self.assertEqual(result._actor_name, from_class._actor_name, "Private is copied if explicitly included")
         self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
 
+    def test_mapping_included_field_by_mapping(self):
+        """Test mapping with included fields by mapping"""
+        #Arrange
+        from_class = FromTestClass()
+        mapper = ObjectMapper()
+        mapper.create_map(FromTestClass, ToTestClass, mapping={'_actor_name': lambda o: f"{o.name} acted by {o._actor_name}"})
+
+        #Act
+        result = mapper.map(FromTestClass())
+
+        #Assert
+        print(result)      
+        self.assertTrue(isinstance(result, ToTestClass), "Type must be ToTestClass")
+        self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
+        self.assertEqual(result.date, from_class.date, "Date mapping must be equal")
+        self.assertEqual(result._actor_name, f"{from_class.name} acted by {from_class._actor_name}", "Private is copied if explicitly mapped")
+        self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
+
     def test_mapping_creation_complex_without_mappings_correct(self):
         """ Test mapping creation for complex class without mappings """
 

--- a/tests/object_mapper_test.py
+++ b/tests/object_mapper_test.py
@@ -30,6 +30,29 @@ class ToTestClassEmpty(object):
         pass
 
 
+class ToTestClassEmpty(object):
+    """ To Test Class Empty """
+    def __init__(self):
+        pass
+
+
+class ToTestComplexClass(object):
+    """ To Test Class """
+    def __init__(self):
+        self.name = ""
+        self.date = ""
+        self.student = None
+        self.knows = None
+        pass
+
+
+class ToTestComplexChildClass(object):
+    """ To Test Class """
+    def __init__(self):
+        self.full_name = ""
+        pass
+
+
 class FromTestClass(object):
     """ From Test Class """
     def __init__(self):
@@ -37,6 +60,25 @@ class FromTestClass(object):
         self.surname = "Hnizdo"
         self.date = datetime(2015, 1, 1)
         pass
+
+
+class FromTestComplexChildClass(object):
+    """ From Test Class """
+    def __init__(self, full_name="Eda Soucek"):
+        self.full_name = full_name
+        pass
+
+
+class FromTestComplexClass(object):
+    """ From Test Class """
+    def __init__(self):
+        self.name = "Igor"
+        self.surname = "Hnizdo"
+        self.date = datetime(2015, 1, 1)
+        self.student = FromTestComplexChildClass()
+        self.knows = [FromTestComplexChildClass('Mrs. Souckova'), FromTestComplexChildClass('The schoolmaster')]
+        pass
+
 
 
 class ObjectMapperTest(unittest.TestCase):
@@ -53,7 +95,7 @@ class ObjectMapperTest(unittest.TestCase):
         mapper.create_map(FromTestClass, ToTestClass)
 
         # Act
-        result = mapper.map(FromTestClass(), ToTestClass)
+        result = mapper.map(FromTestClass())
 
         # Assert
         self.assertTrue(isinstance(result, ToTestClass), "Target types must be same")
@@ -102,7 +144,7 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Arrange
         exc = False
-        msg = "Mapping for FromTestClass -> ToTestClass already exists"
+        msg = "Mapping for tests.object_mapper_test.FromTestClass -> tests.object_mapper_test.ToTestClass already exists"
         mapper = ObjectMapper()
 
         mapper.create_map(FromTestClass, ToTestClass)
@@ -128,7 +170,7 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Act
         try:
-            mapper.map(FromTestClass(), ToTestClass)
+            mapper.map(FromTestClass())
         except ObjectMapperException as ex:
             self.assertEqual(str(ex), msg, "Exception message must be correct")
             exc = True
@@ -153,7 +195,7 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Act
         try:
-            mapper.map(from_class, ToTestClass)
+            mapper.map(from_class)
         except AttributeError as ex:
             exc = ex
 
@@ -176,7 +218,7 @@ class ObjectMapperTest(unittest.TestCase):
         mapper.create_map(FromTestClass, ToTestClass, mappings)
 
         # Act
-        result = mapper.map(from_class, ToTestClass, allow_none=True)
+        result = mapper.map(from_class, allow_none=True)
 
         # Assert
         self.assertEqual(None, result)
@@ -186,14 +228,14 @@ class ObjectMapperTest(unittest.TestCase):
 
         # Arrange
         exc = False
-        msg = "No mapping defined for FromTestClass -> ToTestClass"
+        msg = "No mapping defined for tests.object_mapper_test.FromTestClass"
         from_class = FromTestClass()
 
         mapper = ObjectMapper()
 
         # Act
         try:
-            mapper.map(from_class, ToTestClass)
+            mapper.map(from_class)
         except ObjectMapperException as ex:
             self.assertEqual(str(ex), msg, "Exception message must be correct")
             exc = True
@@ -211,7 +253,7 @@ class ObjectMapperTest(unittest.TestCase):
                           {"name": None})
 
         # Act
-        result1 = mapper.map(from_class, ToTestClass)
+        result1 = mapper.map(from_class)
 
         # Assert
         self.assertTrue(isinstance(result1, ToTestClass), "Type must be ToTestClass")
@@ -238,7 +280,7 @@ class ObjectMapperTest(unittest.TestCase):
         mapper.create_map(FromTestClass2, ToTestClass2)
 
         # Act
-        result = mapper.map(FromTestClass2(), ToTestClass2, ignore_case=True)
+        result = mapper.map(FromTestClass2(), ignore_case=True)
 
         # Assert
         self.assertEqual(result.name, from_class.Name, "Name mapping must be equal")
@@ -253,7 +295,7 @@ class ObjectMapperTest(unittest.TestCase):
                           {"name": lambda x: "{0} {1}".format(x.name, x.surname)})
 
         # Act
-        result1 = mapper.map(from_class, ToTestClass)
+        result1 = mapper.map(from_class)
 
         # Assert
         self.assertTrue(isinstance(result1, ToTestClass), "Type must be ToTestClass")
@@ -294,7 +336,7 @@ class ObjectMapperTest(unittest.TestCase):
         mapper.create_map(FromTestClass, ToCustomDirClass)
 
         # Act
-        result = mapper.map(FromTestClass(), ToCustomDirClass)
+        result = mapper.map(FromTestClass())
 
         # Assert
         self.assertTrue(isinstance(result, ToCustomDirClass), "Target types must be same")
@@ -310,7 +352,7 @@ class ObjectMapperTest(unittest.TestCase):
         mapper.create_map(FromTestClass, ToTestClass)
 
         #Act
-        result = mapper.map(FromTestClass(), ToTestClass, excluded=['date'])
+        result = mapper.map(FromTestClass(), excluded=['date'])
 
         #Assert
         print(result)      
@@ -318,3 +360,26 @@ class ObjectMapperTest(unittest.TestCase):
         self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
         self.assertEqual(result.date, '', "Date mapping must be equal")
         self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
+
+    def test_mapping_creation_complex_without_mappings_correct(self):
+        """ Test mapping creation for complex class without mappings """
+
+        # Arrange
+        from_class = FromTestComplexClass()
+        mapper = ObjectMapper()
+        mapper.create_map(FromTestComplexClass, ToTestComplexClass)
+        mapper.create_map(FromTestComplexChildClass, ToTestComplexChildClass)
+
+        # Act
+        result = mapper.map(from_class)
+
+        # Assert
+        self.assertTrue(isinstance(result, ToTestComplexClass), "Target types must be same")
+        self.assertTrue(isinstance(result.student, ToTestComplexChildClass), "Target types must be same")
+        self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
+        self.assertEqual(result.date, from_class.date, "Date mapping must be equal")
+        self.assertEqual(result.student.full_name, from_class.student.full_name, "StudentName mapping must be equal")
+        self.assertEqual(len(result.knows), len(from_class.knows), "number of entries must be the same for Knows")
+        self.assertTrue(all(isinstance(k, ToTestComplexChildClass) for k in result.knows), "Children target types must be same")
+        self.assertEqual(result.knows[0].full_name, from_class.knows[0].full_name, "StudentName(0) mapping must be equal")
+        self.assertEqual(result.knows[1].full_name, from_class.knows[1].full_name, "StudentName(1) mapping must be equal")

--- a/tests/object_mapper_test.py
+++ b/tests/object_mapper_test.py
@@ -387,7 +387,7 @@ class ObjectMapperTest(unittest.TestCase):
         #Arrange
         from_class = FromTestClass()
         mapper = ObjectMapper()
-        mapper.create_map(FromTestClass, ToTestClass, mapping={'_actor_name': lambda o: f"{o.name} acted by {o._actor_name}"})
+        mapper.create_map(FromTestClass, ToTestClass, mapping={'_actor_name': lambda o: "{0} acted by {1}".format(o.name, o._actor_name)})
 
         #Act
         result = mapper.map(FromTestClass())
@@ -397,7 +397,7 @@ class ObjectMapperTest(unittest.TestCase):
         self.assertTrue(isinstance(result, ToTestClass), "Type must be ToTestClass")
         self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
         self.assertEqual(result.date, from_class.date, "Date mapping must be equal")
-        self.assertEqual(result._actor_name, f"{from_class.name} acted by {from_class._actor_name}", "Private is copied if explicitly mapped")
+        self.assertEqual(result._actor_name, "{0} acted by {1}".format(from_class.name, from_class._actor_name), "Private is copied if explicitly mapped")
         self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
 
     def test_mapping_creation_complex_without_mappings_correct(self):

--- a/tests/object_mapper_test.py
+++ b/tests/object_mapper_test.py
@@ -14,6 +14,7 @@ class ToTestClass(object):
     def __init__(self):
         self.name = ""
         self.date = ""
+        self._actor_name = ""
         pass
 
 
@@ -59,6 +60,7 @@ class FromTestClass(object):
         self.name = "Igor"
         self.surname = "Hnizdo"
         self.date = datetime(2015, 1, 1)
+        self._actor_name = "Jan Triska"
         pass
 
 
@@ -101,6 +103,7 @@ class ObjectMapperTest(unittest.TestCase):
         self.assertTrue(isinstance(result, ToTestClass), "Target types must be same")
         self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
         self.assertEqual(result.date, from_class.date, "Date mapping must be equal")
+        self.assertEqual(result._actor_name, "", "Private should not be copied by default")
         self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
 
     def test_mapping_creation_with_mappings_correct(self):
@@ -359,6 +362,24 @@ class ObjectMapperTest(unittest.TestCase):
         self.assertTrue(isinstance(result, ToTestClass), "Type must be ToTestClass")
         self.assertEqual(result.name, from_class.name, "Name mapping must be equal")
         self.assertEqual(result.date, '', "Date mapping must be equal")
+        self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
+
+    def test_mapping_included_field(self):
+        """Test mapping with included fields"""
+        #Arrange
+        from_class = FromTestClass()
+        mapper = ObjectMapper()
+        mapper.create_map(FromTestClass, ToTestClass)
+
+        #Act
+        result = mapper.map(FromTestClass(), excluded=['name'], included=['name', '_actor_name'])
+
+        #Assert
+        print(result)      
+        self.assertTrue(isinstance(result, ToTestClass), "Type must be ToTestClass")
+        self.assertEqual(result.name, '', "Name must not be copied despite of inclusion, as exclusion take precedence")
+        self.assertEqual(result.date, from_class.date, "Date mapping must be equal")
+        self.assertEqual(result._actor_name, from_class._actor_name, "Private is copied if explicitly included")
         self.assertNotIn("surname", result.__dict__, "To class must not contain surname")
 
     def test_mapping_creation_complex_without_mappings_correct(self):


### PR DESCRIPTION
- made the second type parameter optional for map() call: only needed if there's ambiguity when there's more than one mapping exist for same 'from' class
- used full qualified name for class key
- support nested object mapping (single or list)
- added a new flag to ignore or disallow complex class object member if no mapping for it was defined
- added a parameter to include protected field if explicitly requested