### PR TITLE
Add primitive float type

### DIFF
--- a/mapper/object_mapper.py
+++ b/mapper/object_mapper.py
@@ -15,7 +15,7 @@ class ObjectMapper(object):
     Supports mapping conversions too
     """
 
-    primitive_types = { int, str, bool, date, datetime }
+    primitive_types = { int, float, str, bool, date, datetime }
 
     def __init__(self):
         """Constructor


### PR DESCRIPTION
It seems that the project has been abandoned. But this project is the only object mapper I can see in the Python world. I hope someone from the project sees this simple but necessary "primitive float type addition" and accepts this PR.