### PR TITLE
Update to collections module structure to support python 3.9+

### DIFF
--- a/mapper/casedict.py
+++ b/mapper/casedict.py
@@ -4,8 +4,12 @@ Copyright (c) 2013 Optiflows
 https://bitbucket.org/optiflowsrd/obelus/src/tip/obelus/casedict.py
 """
 
-from collections import MutableMapping
+import sys
 
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 _sentinel = object()
 


### PR DESCRIPTION
Update to the collections module import to support newer versions of python where the `MutableMapping` module has changed. Tested with Python 3.6, 3.8, 3.9, and 3.10 - all tests pass successfully in all versions.